### PR TITLE
Convert MongoDB from set to book

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -4703,7 +4703,7 @@ local: {
        <link linkend="types.comparisons">порівняння</link> і
        <link linkend="language.types.type-juggling">перетворення типів</link> в
        PHP. Для вибірки даних спеціальних BSON-типів, критерії запиту повинні
-       використовувати відповідний <link linkend="book.bson">клас BSON</link>
+       використовувати відповідний <link linkend="mongodb.bson">клас BSON</link>
        (напр. <classname>MongoDB\BSON\ObjectId</classname> для вибірки
        <link xlink:href="&url.mongodb.docs.objectid;"
        xmlns:xlink="http://www.w3.org/1999/xlink">ObjectId</link>).


### PR DESCRIPTION
The MongoDB chapter in `doc-en` is in the process of being updated from a <set> to a <book> in https://github.com/php/doc-en/pull/3627. This PR updates an xml ID that will be renamed after the `doc-en` PR is merged. 