### PR TITLE
Partial steps to fix build

### DIFF
--- a/faq/com.xml
+++ b/faq/com.xml
@@ -237,7 +237,7 @@ $word = new COM("C:\docs\word.doc");
    <qandaentry xml:id="faq.com.q14">
     <question>
      <para>
-      Отже, PHP працює з COM, як щодо COM+ ?
+      Отже, PHP працює з COM, як щодо COM+?
      </para>
     </question>
     <answer>

--- a/faq/com.xml
+++ b/faq/com.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 2bb07c8c43f028c665a33bfc08a22639e9e35dc6 Maintainer: mproshchuk Status: ready -->
+<!-- EN-Revision: e0352653179c355a6b9c353629147b06a2069f24 Maintainer: mproshchuk Status: ready -->
  <chapter xml:id="faq.com" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>PHP і COM</title>
   <titleabbrev>PHP і COM</titleabbrev>
@@ -229,9 +229,7 @@ $word = new COM("C:\docs\word.doc");
     <answer>
      <para>
       Відповідь настільки проста, наскільки і незадовільна. Невідомо, чому так,
-      але не можна нічого з цим вдіяти. Якщо хтось має потрібну інформацію з
-      цього приводу, будь ласка,
-      <link xlink:href="mailto:&email.harald;">дайте знати</link> :)
+      але не можна нічого з цим вдіяти.
      </para>
     </answer>
    </qandaentry>

--- a/install/unix/index.xml
+++ b/install/unix/index.xml
@@ -1,183 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 645c1b0252ac20e344c151a5184d9c8e594f4811 Maintainer: mproshchuk Status: ready -->
+<!-- EN-Revision: 4cb53ecbd763db2db808e90d7eda63afb380e6df Maintainer: mproshchuk Status: ready -->
 
-  <chapter xml:id="install.unix" xmlns="http://docbook.org/ns/docbook">
-   <title>Встановлення на Unix системи</title>
-   <para>
-    Цей розділ описує основне налаштування та встановлення PHP на Unix системи.
-    Варто прочитати всі розділи, призначені для певних платформ чи вебсервера,
-    перш ніж почати процес.
-   </para>
-   <para>
-    Як зазначено в розділі <link linkend="install.general">Загальні інструкції
-    встановлення</link>, ми головним чином працюватимемо над встановленням PHP,
-    що призначається для веб-програмування, хоча згадаємо також і про
-    налаштування PHP для використання в командному рядку.
-   </para>
-   <para> 
-    Є кілька способів встановлення PHP на Unix платформі - або в процесі збірки
-    та конфігурування, або за допомогою готових дистрибутивів. Ця документація в
-    основному сфокусована на процесі збірки та конфігурування PHP. Багато
-    Unix-подібних систем мають певні програми встановлення пакетів. Вони можуть
-    допомогти з налаштуванням стандартної конфігурації, але якщо потрібен інший
-    набір функцій (такий як безпековий сервер, або різні драйвера до баз даних),
-    то може знадобитись компіляція PHP та/або веб-сервера. Якщо ви не знайомі з
-    побудовою та компіляцією вашого програмного забезпечення, варто перевірити
-    чи немає вже готових пакетів, що мають версію PHP з потрібною
-    функціональністю.
-   </para>
-   <para>
-    Необхідні знання та програмне забезпечення для компіляції:
-    <itemizedlist>
-     <listitem>
-      <simpara>
-       Базові знання Unix (вміння оперувати "make" та компілятором C)
-      </simpara>
-     </listitem> 
-     <listitem>
-      <simpara>
-       Компілятор ANSI C
-      </simpara>
-     </listitem> 
-     <listitem>
-      <simpara>
-       Веб-сервер
-      </simpara>
-     </listitem>
-     <listitem>
-      <simpara>
-       Будь-які специфічні компоненти модулів (такі як бібліотеки
-       <acronym>GD</acronym>, <acronym>PDF</acronym>, і т.д.)
-      </simpara>
-     </listitem>
-    </itemizedlist>
-   </para>
+<chapter xml:id="install.unix" xmlns="http://docbook.org/ns/docbook">
+ <title>Встановлення в Unix-системах</title>
+ <simpara>
+  Більшість операційних систем та дистрибутивів на основі Unix (та Linux)
+  надають для встановлення версію PHP та його розширень у вигляді пакунків через
+  свої менеджери пакунків. Нижче є посилання на розділи з основною інформацією
+  про встановлення PHP в цих системах.
+ </simpara>
+ <simpara>
+  Для деяких дистрибутивів існують також сторонні сховища пакунків, які зазвичай
+  містять більшу кількість доступних версій та розширень.
+ </simpara>
+ <simpara>
+  PHP також можна встановити, як компонент деяких сторонніх серверів програм.
+  <!-- such as FrankenPHP and Open Swoole-->.
+ </simpara>
+ <simpara>
+  І нарешті, PHP завжди можна зібрати та встановити з початкових файлів. Такий
+  підхід забезпечує найбільшу гнучкість у виборі функціоналу, розширень та
+  серверних API. Є розділи з інформацією про компіляцію та налаштування PHP,
+  зокрема для використання з різними серверними API.
+ </simpara>
 
-   <para>
-    Для збирання безпосередньо із початкового коду з Git чи після ручних
-    модифікацій також можуть знадобитись:
-    <itemizedlist>
-     <listitem>
-      <simpara>
-       autoconf:
-      </simpara>
-      <itemizedlist>
-       <listitem>
-        <simpara>
-         PHP 7.3 та новіші: 2.68+
-        </simpara>
-       </listitem>
-       <listitem>
-        <simpara>
-         PHP 7.2: 2.64+
-        </simpara>
-       </listitem>
-       <listitem>
-        <simpara>
-         PHP 7.1 та старіші: 2.59+
-        </simpara>
-       </listitem>
-      </itemizedlist>
-     </listitem>
-     <listitem>
-      <simpara>
-       automake: 1.4+
-      </simpara>
-     </listitem>
-     <listitem>
-      <simpara>
-       libtool: 1.4.x+ (окрім 1.4.2)
-      </simpara>
-     </listitem>
-     <listitem>
-      <simpara>
-       re2c:
-      </simpara>
-      <itemizedlist>
-       <listitem>
-        <simpara>
-         PHP 8.3 та новіші: 1.0.3+
-        </simpara>
-       </listitem>
-       <listitem>
-        <simpara>
-         PHP 8.2 та старіші: 0.13.4+
-        </simpara>
-       </listitem>
-      </itemizedlist>
-     </listitem>
-     <listitem>
-      <simpara>
-       bison:
-      </simpara>
-      <itemizedlist>
-       <listitem>
-        <simpara>
-         PHP 7.4 та пізніші: 3.0.0+
-        </simpara>
-       </listitem>
-       <listitem>
-        <simpara>
-         PHP 7.3 та старіші: 2.4+ (включно з Bison 3.x)
-        </simpara>
-       </listitem>
-      </itemizedlist>
-     </listitem>
-    </itemizedlist>
-   </para>
-   
-   <para>
-    Початковий процес встановлення та налаштування PHP контролюється через
-    опції командного рядка під час виконання скрипта
-    <command>configure</command>. Можна побачити список всіх доступних
-    параметрів разом з коротким поясненнями, запустивши <command>./configure
-    --help</command>. Наш посібник документує різні параметри окремо. Можна
-    проглянути <link linkend="configure.about">основні параметри
-    конфігурації</link> в додатковому розділі, тоді як специфічні параметри для
-    різних розширень можна знайти на відповідних сторінках (див. зміст цієї
-    сторінки).
-   </para>
-    
-   <para>
-    Коли PHP сконфігуровано, все готово для побудови модулів та/або виконавчих
-    файлів. Команда <command>make</command> повинна подбати про це. Якщо це не
-    вдається і не зрозуміло, чому — див. розділ <link
-    linkend="install.problems">Проблеми встановлення</link>.
-   </para>
+ <!-- distribution specific nodes -->
+ &install.unix.debian;
+ &install.unix.dnf;
+ &install.unix.openbsd;
+ <!-- general from-source instructions -->
+ &install.unix.source;
+ <!-- web server specific nodes -->
+ &install.unix.commandline;
+ &install.unix.apache2;
+ &install.unix.nginx;
+ &install.unix.lighttpd-14;
+ &install.unix.litespeed;
+ <!-- operating system specific nodes -->
+ &install.unix.solaris;
 
-   <note>
-    <para>
-     З міркувань безпеки деякі системи Unix (як от OpenBSD та SELinux) можуть не
-     дозволяти перезаписувати сторінки пам'яті, що були виділені для інструкцій
-     процесору та навпаки. Цей захист пам'яті називається MPROTECT або W^X.
-     Однак ці обмеження неприпустимі для JIT PCRE, тож PHP має бути побудований
-     <link linkend="pcre.installation">без підтримки PCRE</link>, або двійковий
-     файл повинен бути внесений у білий список будь-якими способами,
-     передбаченими системою.
-    </para>
-   </note>
-
-   <note>
-    <simpara>
-     Перехресне компілювання для ARM за допомогою набору інструментів Android
-     наразі не підтримується.
-    </simpara>
-   </note>
-
-   <!-- web server specific nodes -->
-   &install.unix.apache2;
-   &install.unix.nginx;
-   &install.unix.lighttpd-14;
-   &install.unix.litespeed;
-   &install.unix.commandline;
-   <!-- operating system specific nodes -->
-   &install.unix.openbsd;
-   &install.unix.solaris;
-   <!-- distribution specific nodes -->
-   &install.unix.debian;
-
-   </chapter>
-
+</chapter>
 <!-- Keep this comment at the end of the file
 Local variables:
 mode: sgml

--- a/install/unix/nginx.xml
+++ b/install/unix/nginx.xml
@@ -1,54 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: e2788930738ece61eb73efa693bf783b68fc56fa Maintainer: ktretyak Status: ready -->
-<!-- $Revision$ -->
+<!-- EN-Revision: f0261e36dc250410f352fe33ad4c4e699cb18b02 Maintainer: mproshchuk Status: ready -->
 <sect1 xml:id="install.unix.nginx" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Nginx 1.4.x на Unix системах</title>
 
  <para>
-  В цьому розділі описано встановлення та конфігурування PHP з
-  PHP-FPM для HTTP-сервера Nginx 1.4.x.
+  В цьому розділі описано встановлення та налаштування PHP з PHP-FPM для
+  HTTP-сервера Nginx 1.4.x.
  </para>
 
  <para>
-  Якщо ви збирали Nginx з сирців, то всі бінарні та конфігураційні файли
-  зберігаються в <literal>/usr/local/nginx</literal>. В іншому випадку, можете
-  описати ваш процес встановлення на <link xlink:href="&url.nginx;">Nginx Wiki</link>.
+  Передбачається, що Nginx зібрано з початкових файлів, а всі двійкові та
+  конфігураційні файли зберігаються в <literal>/usr/local/nginx</literal>. В
+  іншому випадку, можна описати процес встановлення на <link
+  xlink:href="&url.nginx;">Nginx Wiki</link>.
  </para>
 
  <para>
-  Тут буде описуватись лише основне конфігурування сервера Nginx, щоб він міг
-  обробляти PHP застосунки на 80-му порту. В іншому випадку рекомендуємо
-  прочитати документацію Nginx для PHP-FPM.
+  Тут описано основне налаштування сервера Nginx для обробки PHP-скриптів на
+  80-му порту. Для інших цілей радимо прочитати документацію Nginx для PHP-FPM.
  </para>
 
  <para>
-  Нижче на цій сторінці будуть зустрічатись маски 'x' на місці номера версії.
-  Це зроблено з узагальнюючою метою, оскільки викладені тут рекомендації підійдуть
-  для ряду версій. Дані маски потрібно замінити на відповідний номер вашої версії
-  Nginx.
+  Оскільки викладені тут рекомендації дійсні для багатьох версій, нижче буде
+  траплятись знак 'x' на місці номера версії. За потреби його можна замінити на
+  потрібне число.
  </para>
 
  <orderedlist>
   <listitem>
    <para>
-    Рекомендуємо відвідати Nginx Wiki та прочитати
-    <link xlink:href="&url.nginx.wiki.install;">сторінку встановлення</link>,
+    Рекомендовано відвідати Nginx Wiki та прочитати <link
+    xlink:href="&url.nginx.wiki.install;">керівництво зі встановлення</link>,
     щоб правильно встановити Nginx.
    </para>
   </listitem>
 
   <listitem>
    <para>
-    Скачайте та розпакуйте сирці PHP:
+    Завантажте розпакуйте початкові файли PHP:
    </para>
 
-   <example xml:id="install.unix.nginx.extract.php">
+   <informalexample xml:id="install.unix.nginx.extract.php">
     <screen>
 <![CDATA[
 tar zxf php-x.x.x
 ]]>
     </screen>
-   </example>
+   </informalexample>
   </listitem>
 
   <listitem>
@@ -59,7 +57,7 @@ tar zxf php-x.x.x
     з підтримкою PHP-FPM та MySQL.
    </para>
 
-   <example xml:id="install.unix.nginx.build.php">
+   <informalexample xml:id="install.unix.nginx.build.php">
     <screen>
 <![CDATA[
 cd ../php-x.x.x
@@ -68,59 +66,59 @@ make
 sudo make install
 ]]>
     </screen>
-   </example>
+   </informalexample>
   </listitem>
 
   <listitem>
    <para>
-    Тепер скопіюємо конфігураційні файли в їхнє коректне місцерозташування
+    Тепер скопіюємо конфігураційні файли в їхнє коректне розташування:
    </para>
 
-   <example xml:id="install.unix.nginx.configure.php">
+   <informalexample xml:id="install.unix.nginx.configure.php">
     <screen>
 <![CDATA[
 cp php.ini-development /usr/local/php/php.ini
-cp /usr/local/etc/php-fpm.conf.default /usr/local/etc/php-fpm.conf
+cp /usr/local/etc/php-fpm.d/www.conf.default /usr/local/etc/php-fpm.d/www.conf
 cp sapi/fpm/php-fpm /usr/local/bin
 ]]>
     </screen>
-   </example>
+   </informalexample>
   </listitem>
 
   <listitem>
    <para>
     Важливо, щоб ми убезпечили Nginx від проходження запитів до
-    PHP-FPM, коли файла не існує. Таким чином ми запобігаємо від довільної
+    PHP-FPM, коли файлу не існує. Таким чином ми запобігаємо від довільної
     ін'єкції скрипта.
    </para>
    <para>
     Це можна зробити встановивши директиву
     <link linkend="ini.cgi.fix-pathinfo">cgi.fix_pathinfo</link>
-    в <literal>0</literal> всередині файла php.ini.
+    в <literal>0</literal> всередині файлу php.ini.
    </para>
    <para>
     Відкриваємо файл php.ini:
    </para>
 
-   <example xml:id="install.unix.nginx.configure.ini">
+   <informalexample xml:id="install.unix.nginx.configure.ini">
     <screen>
 <![CDATA[
 vim /usr/local/php/php.ini
 ]]>
     </screen>
-   </example>
+   </informalexample>
 
    <para>
     Знаходимо директиву <literal>cgi.fix_pathinfo=</literal> та змінюємо її так:
    </para>
 
-   <example xml:id="install.unix.nginx.configure.pathinfo">
+   <informalexample xml:id="install.unix.nginx.configure.pathinfo">
     <screen>
 <![CDATA[
 cgi.fix_pathinfo=0
 ]]>
     </screen>
-   </example>
+   </informalexample>
   </listitem>
 
   <listitem>
@@ -129,19 +127,19 @@ cgi.fix_pathinfo=0
     під користувачем www-data та в групі www-data перед тим, як будемо запускати сервіс:
    </para>
 
-   <example xml:id="install.unix.nginx.modify.phpfpm">
+   <informalexample xml:id="install.unix.nginx.modify.phpfpm">
     <screen>
 <![CDATA[
-vim /usr/local/etc/php-fpm.conf
+vim /usr/local/etc/php-fpm.d/www.conf
 ]]>
     </screen>
-   </example>
+   </informalexample>
 
    <para>
     Знайдіть та змініть наступне: 
    </para>
 
-   <example xml:id="install.unix.nginx.modify.phpfpm.usergroup">
+   <informalexample xml:id="install.unix.nginx.modify.phpfpm.usergroup">
     <screen>
 <![CDATA[
 ; Користувач чи група Unix процесів
@@ -151,19 +149,19 @@ user = www-data
 group = www-data
 ]]>
     </screen>
-   </example>
+   </informalexample>
 
    <para>
     Тепер можна запускати сервіс php-fpm:
    </para>
 
-   <example xml:id="install.unix.nginx.start.phpfpm">
+   <informalexample xml:id="install.unix.nginx.start.phpfpm">
     <screen>
 <![CDATA[
 /usr/local/bin/php-fpm
 ]]>
     </screen>
-   </example>
+   </informalexample>
 
    <para>
     На цьому налаштування php-fpm припиняється, але якщо ви зацікавлені в більш
@@ -176,19 +174,19 @@ group = www-data
     Тепер Nginx потрібно налаштувати для обробки PHP застосунків:
    </para>
 
-   <example xml:id="install.unix.nginx.configure.nginx">
+   <informalexample xml:id="install.unix.nginx.configure.nginx">
     <programlisting>
 <![CDATA[
 vim /usr/local/nginx/conf/nginx.conf
 ]]>
     </programlisting>
-   </example>
+   </informalexample>
 
    <para>
     Змінюємо блок "location", щоб додати до індексних файлів розширення .php:
    </para>
 
-   <example xml:id="install.unix.nginx.configure.nginx.location">
+   <informalexample xml:id="install.unix.nginx.configure.nginx.location">
     <programlisting role="nginx-conf">
 <![CDATA[
 location / {
@@ -197,14 +195,14 @@ location / {
 }
 ]]>
     </programlisting>
-   </example>
+   </informalexample>
 
    <para>
     На наступному кроці ми говоримо, щоб всі файли .php передавались до
     PHP-FPM, нижче від закоментованого блоку location, додайте таке:
    </para>
 
-   <example xml:id="install.unix.nginx.configure.nginx.php">
+   <informalexample xml:id="install.unix.nginx.configure.nginx.php">
     <programlisting role="nginx-conf">
 <![CDATA[
 location ~* \.php$ {
@@ -216,20 +214,20 @@ location ~* \.php$ {
 }
 ]]>
     </programlisting>
-   </example>
+   </informalexample>
 
    <para>
     Перезапускаємо Nginx.
    </para>
 
-   <example xml:id="install.unix.nginx.restart.nginx">
+   <informalexample xml:id="install.unix.nginx.restart.nginx">
     <screen>
 <![CDATA[
 sudo /usr/local/nginx/sbin/nginx -s stop
 sudo /usr/local/nginx/sbin/nginx
 ]]>
     </screen>
-   </example>
+   </informalexample>
   </listitem>
 
   <listitem>
@@ -237,14 +235,14 @@ sudo /usr/local/nginx/sbin/nginx
     Створюємо тестовий файл
    </para>
 
-   <example xml:id="install.unix.nginx.test.nginx.php">
+   <informalexample xml:id="install.unix.nginx.test.nginx.php">
     <screen>
 <![CDATA[
 rm /usr/local/nginx/html/index.html
 echo "<?php phpinfo(); ?>" >> /usr/local/nginx/html/index.php
 ]]>
     </screen>
-   </example>
+   </informalexample>
 
    <para>
     Перейдіть за адресою http://localhost. Тепер phpinfo() вже повинно виводитись.
@@ -254,7 +252,7 @@ echo "<?php phpinfo(); ?>" >> /usr/local/nginx/html/index.php
 
  <para>
   Дотримуючись кроків, описаних вище, ви матимете робочий веб-сервер Nginx,
-  який підтримує PHP як модуль <literal>SAPI</literal>. Звичайно є набагато
+  який підтримує PHP як модуль <literal>FPM</literal> <literal>SAPI</literal>. Звичайно є набагато
   більше параметрів конфігурації доступних для Nginx та PHP. Більше інформації
   можна отримати ввівши в консолі <command>./configure --help</command> в їх
   кореневих каталогах.

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 1cdefe36cdfc0e3acaff6a0db918d4b037081aa8 Maintainer: mproshchuk Status: ready -->
+<!-- EN-Revision: 17a5268812b06c23073609c4e8ab976ebfceb61b Maintainer: mproshchuk Status: ready -->
 
 <!ENTITY installation.enabled.disable
 'Це розширення початково увімкнено. Для вимкнення застосовується наступна опція
@@ -423,6 +423,11 @@ linkend="userlandnaming" />.</simpara></tip>'>
 <emphasis>ЗАСТАРІЛА</emphasis>, починаючи з PHP 8.3.0. Вкрай не рекомендується
 на неї покладатися.</simpara></warning>'>
 
+<!ENTITY warn.deprecated.function-8-4-0
+'<warning xmlns="http://docbook.org/ns/docbook"><simpara>Ця функція
+<emphasis>ЗАСТАРІЛА</emphasis>, починаючи з PHP 8.4.0. Вкрай не рекомендується
+на неї покладатися.</simpara></warning>'>
+
 <!ENTITY removed.php.future
 'Цей застарілий функціонал буде <emphasis
 xmlns="http://docbook.org/ns/docbook">обов&apos;язково</emphasis>
@@ -746,6 +751,15 @@ linkend="ini.error-reporting">error_reporting</link> має бути зниже�
 <!ENTITY example.outputs.83.similar
 '<para xmlns="http://docbook.org/ns/docbook">В PHP 8.3 поданий вище приклад
 виведе щось схоже на:</para>'>
+
+<!ENTITY example.outputs.84
+'<para xmlns="http://docbook.org/ns/docbook">В PHP 8.4 поданий вище приклад
+виведе:</para>'>
+
+<!ENTITY example.outputs.84.similar
+'<para xmlns="http://docbook.org/ns/docbook">В PHP 8.4 поданий вище приклад
+виведе щось схоже на:</para>'>
+
 
 <!ENTITY example.outputs.32bit
 '<para xmlns="http://docbook.org/ns/docbook">На 32-бітних машинах поданий вище
@@ -1271,6 +1285,18 @@ GD2 є пропрієтарними форматами зображень libgd.
  </entry>
 </row>'>
 
+<!-- CSV -->
+<!ENTITY warning.csv.escape-parameter
+'<warning xmlns="http://docbook.org/ns/docbook"
+xmlns:xlink="http://www.w3.org/1999/xlink"><simpara>
+ Якщо значенням параметра <parameter>escape</parameter> не є порожній рядок
+ (<literal>""</literal>), то результатом може бути CSV, що не відповідає вимогам
+ <link xlink:href="&url.rfc;4180">RFC 4180</link> або не зможе оброблятись
+ функціями PHP CSV. Типовим значенням параметра <parameter>escape</parameter> є
+ <literal>"\\"</literal>, але рекомендовано явно вказати порожній рядок. Типове
+ значення зміниться в наступній версії PHP, та не раніше, ніж в PHP 9.0.
+</simpara></warning>'>
+
 <!-- DBM notes -->
 
 <!ENTITY dbm.dbm-identifier.description
@@ -1335,6 +1361,23 @@ xmlns="http://docbook.org/ns/docbook"><term><parameter>share_handle</parameter>
   <parameter>share_handle</parameter> тепер має бути примірником класу
   <classname>CurlShareHandle</classname>; раніше очікувався
   <type>resource</type>.
+ </entry>
+</row>'>
+
+<!-- dba notes -->
+<!ENTITY dba.parameter.dba
+'Примірник <classname
+xmlns="http://docbook.org/ns/docbook">Dba\Connection</classname>, якого повертає
+функція <function xmlns="http://docbook.org/ns/docbook">dba_open</function> або
+<function xmlns="http://docbook.org/ns/docbook">dba_popen</function>.'>
+
+<!ENTITY dba.changelog.dba-object
+'<row xmlns="http://docbook.org/ns/docbook">
+ <entry>8.4.0</entry>
+ <entry>
+  Тепер параметр <parameter>dba</parameter> має бути примірником
+  <classname>Dba\Connection</classname>. раніше очікувався дійсний
+  <literal>dba</literal> &resource;.
  </entry>
 </row>'>
 
@@ -1803,6 +1846,53 @@ linkend="memcached.expiration" xmlns="http://docbook.org/ns/docbook">Термі�
 <!ENTITY gearman.parameter.unique 'Унікальний ID завдання'>
 
 <!ENTITY gearman.parameter.jobhandle 'Дескриптор завдання, що призначається сервером Gearman'>
+
+<!ENTITY gearman.parameter.callback
+'<varlistentry xmlns="http://docbook.org/ns/docbook">
+ <term><parameter>callback</parameter></term>
+ <listitem>
+  <para>
+   Назва функції або методу для виклику, що має повертати <link
+   linkend="gearman.constants">Gearman-значення</link>.
+  </para>
+  <para>
+   Якщо оператор return відсутній, то типовим значенням є
+   <constant>GEARMAN_SUCCESS</constant>.
+  </para>
+  <methodsynopsis>
+   <type>int</type><methodname><replaceable>callback</replaceable></methodname>
+   <methodparam><type>GearmanTask</type><parameter>task</parameter></methodparam>
+   <methodparam><type>mixed</type><parameter>context</parameter></methodparam>
+  </methodsynopsis>
+  <variablelist>
+   <varlistentry>
+    <term><parameter>task</parameter></term>
+    <listitem>
+     <para>
+      Завдання, для якого викликається зворотній виклик.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><parameter>context</parameter></term>
+    <listitem>
+     <para>
+      Те, що передано в <methodname>GearmanClient::addTask</methodname> (або
+      рівнозначний метод) як <parameter>context</parameter>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </listitem>
+</varlistentry>'>
+
+<!ENTITY gearman.note.callback
+'<note xmlns="http://docbook.org/ns/docbook">
+ <para>
+  Зворотній виклик спрацьовує лише для завдань, які були додані (напр. методом
+  <methodname>GearmanClient::addTask</methodname>) після виклику цього методу.
+ </para>
+</note>'>
 
 <!-- Date and time entities -->
 <!ENTITY date.timezone.intro.title '<title xmlns="http://docbook.org/ns/docbook">Список підтримуваних часових поясів</title>'>
@@ -2407,10 +2497,6 @@ xmlns="http://docbook.org/ns/docbook" linkend="configuration.changes.modes"/>.'>
 скомпільовано як частина PHP або динамічно підключене під час виконання.
 </simpara>'>
 
-<!ENTITY note.extension.php5
-'<note xmlns="http://docbook.org/ns/docbook"><simpara>
-Це розширення потребує PHP 5.</simpara></note>'>
-
 <!-- PDO entities -->
 <!ENTITY pdo.driver-constants
 '<simpara xmlns="http://docbook.org/ns/docbook">Константи, описані нижче —
@@ -2577,17 +2663,6 @@ xmlns="http://docbook.org/ns/docbook">PECL</acronym>-розширення дос
 <!ENTITY safemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.safe-mode">безпечний режим</link>'>
 
 <!ENTITY sqlsafemode '<link xmlns="http://docbook.org/ns/docbook" linkend="ini.sql.safe-mode">безпечний режим для SQL</link>'>
-
-<!-- APD Notes -->
-<!ENTITY apd.debug-level.description
-'<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>debug_level</parameter></term><listitem><para>Ціле число, утворене
-додаванням <literal>XXX_TRACE</literal>-констант.</para><para>Не рекомендовано
-використовувати <constant>MEMORY_TRACE</constant>. Це дуже повільно і не
-виглядає точним. <constant>ASSIGNMENT_TRACE</constant> ще не
-впроваджено.</para><para>Щоб увімкнути докладне відстеження (TIMING, FUNCTIONS,
-ARGS SUMMARY (як "strace -c")), вказується число 99.</para>
-</listitem></varlistentry>'>
 
 <!-- BCMath Notes -->
 <!ENTITY bc.scale.description
@@ -2767,29 +2842,6 @@ mysqli (<constant>MYSQLI_REPORT_ERROR</constant>) і запитана опера
 '<note xmlns="http://docbook.org/ns/docbook"><simpara>Ця функція встановлює
 NULL-полям значення PHP &null;.</simpara></note>'>
 
-<!-- MSQL Notes -->
-<!-- The msql.*.description entities are used in the parameters refsect1 -->
-<!ENTITY msql.linkid.description
-'<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>link_identifier</parameter></term><listitem><para>З&apos;єднання
-mSQL. Якщо не задано, буде обрано останнє з&apos;єднання, встановлене функцією
-<function>msql_connect</function>. Якщо з&apos;єднатися не вдалось, функція
-спробує встановити нове, ніби викликавши функцію
-<function>msql_connect</function>.</para></listitem></varlistentry>'>
-
-<!ENTITY msql.result.description
-'<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>result</parameter></term><listitem><para>Результат типу
-<type>resource</type> для опрацювання, якого повертає функція
-<function>msql_query</function>.</para></listitem></varlistentry>'>
-
-<!ENTITY msql.field-offset.req.description
-'<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>field_offset</parameter></term><listitem><para>Числовий зсув поля.
-Значення <parameter>field_offset</parameter> починається з
-<literal>1</literal>.</para></listitem></varlistentry>'>
-
-
 <!-- MySQL Notes -->
 <!-- The mysql.*.description entities are used in the parameters refsect1 -->
 <!ENTITY mysql.linkid.description 
@@ -2878,49 +2930,6 @@ MySQL</link> була вилучена з PHP 7.0.0. Краще використ
 <link linkend="language.types.resource.self-destruct">Вивільнення
 ресурсів</link></para>'>
 
-<!-- Sybase Notes -->
-<!ENTITY sybase.ct.only
-'<note xmlns="http://docbook.org/ns/docbook"><simpara>Ця функція доступна тільки
-з використанням інтерфейсу бібліотеки CT до Sybase, але не бібліотеки DB.
-</simpara></note>'>
-
-<!ENTITY sybase.db.only
-'<note xmlns="http://docbook.org/ns/docbook"><simpara>Ця функція доступна тільки
-з використанням інтерфейсу бібліотеки DB до Sybase, але не бібліотеки CT.
-</simpara></note>'>
-
-<!ENTITY sybase.linkid.description
-'<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>link_identifier</parameter></term><listitem><para>З&apos;єднання
-Sybase. Якщо не задано, буде обрано останнє з&apos;єднання, встановлене функцією
-<function>sybase_connect</function>. Якщо з&apos;єднатися не вдалось, функція
-спробує встановити нове, ніби викликавши функцію
-<function>sybase_connect</function> без параметрів. Якщо з&apos;єднання не
-вдалося знайти або встановити, буде виведено повідомлення рівня
-<constant>E_WARNING</constant>.</para></listitem></varlistentry>'>
-
-<!-- CPDF Notes -->
-<!ENTITY cpdf.ul
-'<para xmlns="http://docbook.org/ns/docbook">Необов&apos;язковий параметр
-<parameter>mode</parameter>, яким вказується одиниця довжини. Якщо задано
-<literal>0</literal> або опущено, буде обрано стандартну для поточної сторінки.
-У інших випадках координати вимірюються в пунктах postscript, без урахування
-заданої одиниці вимірювання.</para>'>
-
-<!ENTITY cpdf.mode.description
-'<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>mode</parameter></term><listitem><para>Необов&apos;язковий параметр
-<parameter>mode</parameter>, яким вказується одиниця довжини. Якщо задано
-<literal>0</literal> або опущено, буде обрано стандартну для поточної сторінки.
-У інших випадках координати вимірюються в пунктах postscript, без урахування
-заданої одиниці вимірювання.</para></listitem></varlistentry>'>
-
-<!ENTITY cpdf.pdf-document.description
-'<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>pdf_document</parameter></term><listitem><para>Дескриптор документа,
-якого повертає функція
-<function>cpdf_open</function>.</para></listitem></varlistentry>'>
-
 <!-- Xattr entities -->
 <!ENTITY xattr.namespace
 '<para xmlns="http://docbook.org/ns/docbook">Розширені атрибути мають два різні
@@ -2935,10 +2944,6 @@ Sybase. Якщо не задано, буде обрано останнє з&apos
 IPv6-адресу (напр. <literal>fe80::1</literal>), необхідно взяти IP-адресу в
 квадратні дужки, наприклад,
 <literal>tcp://[fe80::1]:80</literal>.</simpara></note>'>
-
-<!ENTITY ipv6.php5
-'<note xmlns="http://docbook.org/ns/docbook"><simpara>IPv6 підтримується,
-починаючи з PHP 5.0.0.</simpara></note>'>
 
 <!-- Notes for tidy -->
 <!ENTITY tidy.object 'Об&apos;єкт <classname xmlns="http://docbook.org/ns/docbook">Tidy</classname>.'>
@@ -2965,6 +2970,17 @@ xlink:href="&url.tidy.conf;">&url.tidy.conf;</link>.</para><para>Парамет�
 Замість нього краще обрати prefork MPM, який початково йде з Apache 2.0 та 2.2.
 Докладніше — у розділі <link linkend="faq.installation.apache2">Apache 2 з
 потоковим MPM</link></para></warning>'>
+
+<!ENTITY warn.install.third-party-support
+'<warning xmlns="http://docbook.org/ns/docbook"
+xmlns:xlink="http://www.w3.org/1999/xlink">
+ <para>
+  Збірки від сторонніх розробників вважаються неофіційними і безпосередньо
+  проектом PHP не підтримуються. Про знайдені вади, якщо вони не можуть бути
+  відтворені на <link xlink:href="&url.php.downloads;">офіційних збірках</link>,
+  необхідно повідомляти постачальників цих неофіційних збірок.
+ </para>
+</warning>'>
 
 <!ENTITY note.apache.slashes
 '<note xmlns="http://docbook.org/ns/docbook"><simpara>Варто зауважити, що у 
@@ -3002,25 +3018,11 @@ xlink:href="&url.tidy.conf;">&url.tidy.conf;</link>.</para><para>Парамет�
 
 <!ENTITY listendand ' та'>
 
-<!-- classkit and runkit entities -->
-<!ENTITY note.classkit.selfmanipulation
-'<note xmlns="http://docbook.org/ns/docbook"><simpara>Цю функцію не можна
-використати для впливу на метод (чи ланцюжок методів), що
-виконується.</simpara></note>'>
-
+<!-- runkit entities -->
 <!ENTITY note.runkit.selfmanipulation
 '<note xmlns="http://docbook.org/ns/docbook"><simpara>Цю функцію не можна
 використати для впливу на метод (чи ланцюжок методів), що
 виконується.</simpara></note>'>
-
-<!ENTITY note.runkit.sandbox
-'<note xmlns="http://docbook.org/ns/docbook"><simpara>Підтримка Sandbox
-(необхідна для функцій <function>runkit_lint</function>,
-<function>runkit_lint_file</function> та класу
-<classname>Runkit_Sandbox</classname>) доступна, починаючи з PHP 5.1.0 або
-спеціальної зміненої версії PHP 5.0, та потребує увімкненої безпеки потоку.
-Більше інформації міститься у файлі <filename>README</filename> пакунку
-runkit.</simpara></note>'>
 
 <!ENTITY note.runkit.internal-override
 '<note xmlns="http://docbook.org/ns/docbook"><simpara>Зазвичай тільки
@@ -3249,36 +3251,12 @@ linkend="imagick.constants.channel">константи каналу</link> по�
 </note>
 '>
 
-<!ENTITY com.use-oo-instead
-'<note xmlns="http://docbook.org/ns/docbook">
- <simpara>
-  Цієї функції немає в PHP 5. Натомість, для доступу до властивостей або виклику
-  методів краще використовувати звичайний і більш природний
-  об&apos;єктно-орієнтований синтаксис.
- </simpara>
-</note>
-'>
-
 <!-- phar -->
 <!ENTITY phar.write
 '<note xmlns="http://docbook.org/ns/docbook"><para>Для роботи з об&apos;єктами
 <classname>Phar</classname> цей метод потребує, щоб директива &php.ini;
 <literal>phar.readonly</literal> мала значення <literal>0</literal>. Інакше буде
 викинуто <classname>PharException</classname>.</para></note>'>
-
-<!ENTITY phar.removed.pharcompress
-'<note xmlns="http://docbook.org/ns/docbook"><para>Цей метод вилучено з
-розширення phar, починаючи з версії 2.0.0. Тепер подібний функціонал реалізують
-методи <function>Phar::compress</function>,
-<function>Phar::decompress</function>, <function>Phar::compressFiles</function>
-і <function>Phar::decompressFiles</function>.</para></note>'>
-
-<!ENTITY phar.removed.pharfileinfocompress
-'<note xmlns="http://docbook.org/ns/docbook"><para>Цей метод вилучено з
-розширення phar, починаючи з версії 2.0.0. Тепер подібний функціонал реалізують
-методи <function>PharFileInfo::isCompressed</function>,
-<function>PharFileInfo::decompress</function> і
-<function>PharFileInfo::compress</function>.</para></note>'>
 
 <!ENTITY phar.note.performance
 '<note xmlns="http://docbook.org/ns/docbook">
@@ -3398,10 +3376,14 @@ xmlns="http://docbook.org/ns/docbook">Reflection</classname>, що експор�
 <!ENTITY spl.exceptions.intro.title
 '<title xmlns="http://docbook.org/ns/docbook">Виключення</title>'>
 
-<!ENTITY spl.exceptions.intro
-'<para xmlns="http://docbook.org/ns/docbook">SPL містить набір стандартних
-виключень.</para><para xmlns="http://docbook.org/ns/docbook">Також варто
-переглянути <xref linkend="reserved.exceptions" />.</para>'>
+<!ENTITY spl.exceptions.intro '
+ <para xmlns="http://docbook.org/ns/docbook">
+  SPL містить набір стандартних виключень.
+ </para>
+ <para xmlns="http://docbook.org/ns/docbook">Також варто переглянути <xref
+ linkend="reserved.exceptions" />.
+ </para>
+'>
 
 <!ENTITY spl.files.intro.title
 '<title xmlns="http://docbook.org/ns/docbook">Обробка файлів</title>'>
@@ -3670,362 +3652,6 @@ linkend="constant.trader-real-max">TRADER_REAL_MAX</link>.'>
 
 <!ENTITY trader.arg.fast.limit 'Верхня межа адаптивного алгоритму. Допустимі значення від 0.01 до 0.99.'>
 <!ENTITY trader.arg.slow.limit 'Нижня межа адаптивного алгоритму. Допустимі значення від 0.01 до 0.99.'>
-
-<!-- Mongo -->
-<!ENTITY mongo.setreadpreference.parameters
-'<variablelist xmlns="http://docbook.org/ns/docbook"><varlistentry><term>
-<parameter>read_preference</parameter></term><listitem><para>Режим налаштувань
-читання: <constant>MongoClient::RP_PRIMARY</constant>,
-<constant>MongoClient::RP_PRIMARY_PREFERRED</constant>,
-<constant>MongoClient::RP_SECONDARY</constant>,
-<constant>MongoClient::RP_SECONDARY_PREFERRED</constant> або
-<constant>MongoClient::RP_NEAREST</constant>.</para></listitem></varlistentry>
-<varlistentry><term><parameter>tags</parameter></term><listitem><para>Масив з
-нуля або більше наборів тегів у вигляді масивів критеріїв, що використовуються
-для зіставлення тегів з членами набору
-реплік.</para></listitem></varlistentry></variablelist>'>
-
-<!ENTITY mongo.setreadpreference.returnvalues
-'<para xmlns="http://docbook.org/ns/docbook">Повертає &true; у разі успіху або
-&false; у разі невдачі.</para>'>
-
-<!ENTITY mongo.setreadpreference.errors
-'<para xmlns="http://docbook.org/ns/docbook">Видає
-<constant>E_WARNING</constant>, якщо будь-який параметр хибний або якщо один чи
-більше наборів тегів передано у режимі
-<constant>MongoClient::RP_PRIMARY</constant>.</para>'>
-
-<!ENTITY mongo.getreadpreference.returnvalues
-'<para xmlns="http://docbook.org/ns/docbook">Ця функція повертає масив, що
-описує налаштування читання. Він містить значення <literal>type</literal> для
-режиму налаштувань читання рядка (є одною з констант
-<classname>MongoClient</classname>) та вкладений масив
-<literal>tagsets</literal> критеріїв набору тегів. Якщо набори тегів не
-задані, <literal>tagsets</literal> буде відсутнім.</para>'>
-
-<!ENTITY mongo.setwriteconcern.parameters
-'<variablelist xmlns="http://docbook.org/ns/docbook"><varlistentry><term>
-<parameter>w</parameter></term><listitem><para>Вимоги для запису. Може бути
-цілим числом, що вказує кількість серверів, необхідних для підтвердження запису,
-або назвою режиму у вигляді рядка (напр.
-"majority").</para></listitem></varlistentry>
-<varlistentry><term><parameter>wtimeout</parameter></term><listitem><para>Час
-очікування (у мілісекундах) на виконання сервером вимог щодо
-запису.</para></listitem></varlistentry></variablelist>'>
-
-<!ENTITY mongo.setwriteconcern.returnvalues
-'<para xmlns="http://docbook.org/ns/docbook">Повертає &true; у разі успіху або
-&false; у разі невдачі.</para>'>
-
-<!ENTITY mongo.setwriteconcern.errors
-'<para xmlns="http://docbook.org/ns/docbook">Видає
-<constant>E_WARNING</constant>, якщо параметр <literal>w</literal> не є рядком
-або цілим числом.</para>'>
-
-<!ENTITY mongo.getwriteconcern.returnvalues
-'<para xmlns="http://docbook.org/ns/docbook">Ця функція повертає масив, що
-описує вимоги щодо запису. Масив містить цілочисельні або рядкові значення
-рівня підтвердження <literal>w</literal>, а також <literal>wtimeout</literal> —
-час очікування (у мілісекундах) на виконання сервером вимог щодо запису.</para>'>
-
-<!ENTITY mongo.command.parameters.maxtimems
-'<listitem xmlns="http://docbook.org/ns/docbook"><para>
-<literal>"maxTimeMS"</literal></para><para>Визначає сукупний час очікування (в
-мілісекундах) обробки операції на сервері (без урахування простою). Якщо
-операція не виконана за відведений час, буде викинуто
-<classname>MongoExecutionTimeoutException</classname>.</para></listitem>'>
-
-<!ENTITY mongo.index.parameters.background
-'<listitem xmlns="http://docbook.org/ns/docbook"><para>
-<literal>"background"</literal></para><para>Створює індекс у фоновому режимі,
-тож <emphasis>не</emphasis> призупиняє роботу бази даних. Для цього необхідно
-вказати переметру значення &true;. Початково: &false;.</para><warning
-xmlns="http://docbook.org/ns/docbook"><para>До MongoDB 2.6.0, створення індексу
-є операцією вищого пріоритету, незалежно від цього налаштування. Докладніше:
-<link xlink:href="&url.mongodb.dochub.indexes.rs;"
-xmlns:xlink="http://www.w3.org/1999/xlink">Створення індексів з наборами
-копій</link>.</para></warning></listitem>'>
-
-<!ENTITY mongo.index.parameters.dropdups
-'<listitem xmlns="http://docbook.org/ns/docbook">
-<para><literal>"dropDups"</literal></para><para>Застосовується для примусового
-створення унікального індексу ключів в колекції, що повторюються. Початково:
-&false;. Якщо задано &true;, то MongoDB проіндексує перший знайдений ключ, а
-інші документи, що містять такий самий ключ — видалить.</para>
-<warning xmlns="http://docbook.org/ns/docbook">
-<para><literal>"dropDups"</literal> може видалити дані з бази даних. Тож
-використовувати цей параметр необхідно з особливою обережністю.</para></warning>
-<note xmlns="http://docbook.org/ns/docbook"><para>Цей параметр не підтримується
-в MongoDB 2.8+,а створити індекси неможливо, якщо колекція містить однакові
-значення.</para></note></listitem>'>
-
-<!ENTITY mongo.index.parameters.expireafterseconds
-'<listitem xmlns="http://docbook.org/ns/docbook">
-<para><literal>"expireAfterSeconds"</literal></para><para>Термін дії документа в
-секундах, після закінчення якого документ буде автоматично видалено з колекції.
-Цей параметр сумісний тільки з індексами з одним полем, що містить
-<classname>MongoDate</classname>-значення.</para>
-<note xmlns="http://docbook.org/ns/docbook"><para>Цей функціонал доступний у
-MongoDB 2.2+. Докладніше: <link xlink:href="&url.mongodb.docs.expire_data;"
-xmlns:xlink="http://www.w3.org/1999/xlink">Як вказати термін дії даних в
-колекції</link>.</para></note></listitem>'>
-
-<!ENTITY mongo.index.parameters.name
-'<listitem xmlns="http://docbook.org/ns/docbook">
-<para><literal>"name"</literal></para><para>Необов&apos;язковий параметр, який
-однозначно ідентифікує індекс.</para>
-<note xmlns="http://docbook.org/ns/docbook"><para>Стандартно драйвер створює
-назву індексу на основі індексованих полів і порядку/типу. Наприклад, складений
-індекс <literal>array("x" => 1, "y" => -1)</literal> матиме назву
-<literal>"x_1_y_-1"</literal>, а геопросторовий індекс
-<literal>array("loc" => "2dsphere")</literal> називатиметься
-<literal>"loc_2dsphere"</literal>. Створена назва для індексу з багатьма полями
-може перевищити <link xlink:href="&url.mongodb.docs.limits;#Index-Name-Length"
-xmlns:xlink="http://www.w3.org/1999/xlink">допустиму довжину назви
-індексу</link> MongoDB. В такому випадку і використовується параметр
-<literal>"name"</literal>, щоб вказати коротшу назву.</para></note></listitem>'>
-
-<!ENTITY mongo.index.parameters.sparse
-'<listitem xmlns="http://docbook.org/ns/docbook">
-<para><literal>"sparse"</literal></para><para>Cтворює вибірковий індекс для
-документів, які містять вказане поле. Початково: &false;.</para></listitem>'>
-
-<!ENTITY mongo.index.parameters.unique
-'<listitem xmlns="http://docbook.org/ns/docbook">
-<para><literal>"unique"</literal></para><para>Створює унікальний індекс.
-Початково: &false;. Цей параметр стосується тільки зростаючих/спадаючих
-індексів.</para><note xmlns="http://docbook.org/ns/docbook"><para>Якщо MongoDB
-індексує поле, а документ не має значення для цього поля, то індексується
-значення &null;. Якщо кілька документів не містять певного поля, то унікальний
-індекс застосовується тільки до першого з них. Щоб уникнути індексування
-документів без полів, застосовується параметр
-<literal>"sparse"</literal>.</para></note></listitem>'>
-
-<!ENTITY mongo.listcollections.note
-'<note xmlns="http://docbook.org/ns/docbook"><simpara>Цей метод застосовує
-команду <link xlink:href="&url.mongodb.docs.command;listCollections"
-xmlns:xlink="http://www.w3.org/1999/xlink">listCollections</link> під час роботи
-з MongoDB 2.8+. Для попередніх версій метод запитуватиме спеціальну колекцію
-<literal>system.namespaces</literal>.</simpara></note>'>
-
-<!ENTITY mongo.listcollections.parameters.filter
-'<listitem xmlns="http://docbook.org/ns/docbook">
-<para><literal>"filter"</literal></para><para>Необов&apos;язковий критерій
-запиту. Використовується для фільтрації колекцій, включених до
-результату.</para><para>Відповідні поля, які можна запитувати, включають
-<literal>"name"</literal> (назва колекції у вигляді рядка, без префіксу з назвою
-БД) та <literal>"options" (об&apos;єкт, що містить параметри створення
-колекції)</literal>.
-</para><note><simpara>MongoDB 2.6 та старіші версії потребують, щоб вказаний
-критерій <literal>"name"</literal> був рядком, оскільки під час запиту до 
-колекції <literal>system.namespaces</literal> до нього дододається префікс БД.
-Новіші версії MongoDB не мають цього обмеження, оскільки драйвер використовує
-команду "listCollections".</simpara></note></listitem>'>
-
-<!ENTITY mongo.listcollections.parameters.includesystemcollections
-'<listitem xmlns="http://docbook.org/ns/docbook">
-<para><literal>"includeSystemCollections"</literal></para><para>Визначає, чи
-включати системні колекції в результат. Початково: &false;.</para></listitem>'>
-
-<!ENTITY mongo.writes.parameters.writeconcern
-'<listitem xmlns="http://docbook.org/ns/docbook">
-<para><literal>"w"</literal></para><para>Стандартне значення для 
-<classname>MongoClient</classname>: <literal>1</literal>. Докладніше:
-<link linkend="mongo.writeconcerns">Вимоги для запису</link>.</para></listitem>'>
-
-<!ENTITY mongo.writes.parameters.writeconcerntimeout
-'<listitem xmlns="http://docbook.org/ns/docbook">
-<para><literal>"wtimeout"</literal></para><para>Застарілий псевдонім
-<literal>"wTimeoutMS"</literal>.</para></listitem>'>
-
-<!ENTITY mongo.writes.parameters.writeconcerntimeoutms
-'<listitem xmlns="http://docbook.org/ns/docbook">
-<para><literal>"wTimeoutMS"</literal></para><para>Визначає час очікування (у
-мілісекундах) на виконання <link linkend="mongo.writeconcerns">вимог щодо
-запису</link>. Працює тільки коли <literal>"w"</literal> більший за
-<literal>1</literal>, оскільки час очікування стосується реплікації. Якщо вимогу
-не задоволено у межах часу очікування, то викидається
-<classname>MongoCursorException</classname>. Значення <literal>0</literal>
-знімає обмеження в часі. Початкове значення для
-<classname>MongoClient</classname>: <literal>10000</literal> (десять
-секунд).</para></listitem>'>
-
-<!ENTITY mongo.writes.parameters.fsync
-'<listitem xmlns="http://docbook.org/ns/docbook">
-<para><literal>"fsync"</literal></para><para>Якщо &true;, вмикає підтверджені
-"INSERT", значення параметра <literal>"w"</literal> змінює на
-<literal>0</literal>, а операції запису сихронізує з файлами БД на диску.
-Початково: &false;.</para><note><simpara>Не рекомендовано використовувати цей
-параметр, якщо увімкнено журналювання, оскільки він працюватиме так само як
-<literal>"j"</literal>. Використання <literal>"fsync"</literal> разом з
-<literal>"j"</literal> призведе до помилки.</simpara></note></listitem>'>
-
-<!ENTITY mongo.writes.parameters.sockettimeoutms
-'<listitem xmlns="http://docbook.org/ns/docbook">
-<para><literal>"socketTimeoutMS"</literal></para><para>Визначає час очікування
-(у мілісекундах) на з&apos;єднання через сокет. Якщо сервер не відповів за
-відведений час, буде викинуто <classname>MongoCursorTimeoutException</classname>
-і не буде змоги визначити, чи сервер обробив запис. Значення
-<literal>-1</literal> знімає обмеження в часі. Початкове значення для
-<classname>MongoClient</classname>: <literal>30000</literal> (тридцять
-секунд).</para></listitem>'>
-
-<!ENTITY mongo.writes.parameters.journal
-'<listitem xmlns="http://docbook.org/ns/docbook">
-<para><literal>"j"</literal></para><para>Примусово блокує операції запису, щоб
-вони були синхронізовані з журналом на диску. Якщо &true;, застосовуються
-підтвердження запису, а значення параметра <literal>"w"</literal>
-змінюється на <literal>0</literal>. Початково: &false;.</para>
-<note><simpara>Якщо використати "j", кол журналювання вимкнено, MongoDB 2.6+
-видасть помилку і запис не вдасться, тоді як старіші версії просто
-ігнорувантимуть цей параметр.</simpara></note></listitem>'>
-
-<!ENTITY mongo.writes.parameters.safe
-'<listitem xmlns="http://docbook.org/ns/docbook">
-<para><literal>"safe"</literal></para><para>Застарілий параметр. Натомість
-застосовується параметр <link linkend="mongo.writeconcerns">вимог щодо
-запису</link> <literal>"w"</literal>.</para></listitem>'>
-
-<!ENTITY mongo.writes.parameters.timeout
-'<listitem xmlns="http://docbook.org/ns/docbook">
-<para><literal>"timeout"</literal></para><para>Застарілий псевдонім
-<literal>"socketTimeoutMS"</literal>.</para></listitem>'>
-
-<!ENTITY mongo.errors.exceptions.writeconcern
-'<para xmlns="http://docbook.org/ns/docbook">Викидає
-<classname>MongoCursorException</classname>, якщо задано <literal>"w"</literal>
-і запис не вдався.</para><para xmlns="http://docbook.org/ns/docbook">Викидає
-<classname>MongoCursorTimeoutException</classname>, якщо параметр
-<literal>"w"</literal> має значення, більше за 1, а операція займає більше
-ніж <varname>MongoCursor::$timeout</varname> мілісекунд. Це не припинить
-операцію на сервері. Час <varname>MongoCollection::$wtimeout</varname> задається
-в мілісекундах.</para>'>
-
-<!ENTITY mongo.errors.deprecated
-'<para xmlns="http://docbook.org/ns/docbook">Видає попередження
-<constant>E_DEPRECATED</constant>.</para>'>
-
-<!ENTITY mongo.gridfs.store.metadata.note
-'<note xmlns="http://docbook.org/ns/docbook"><para>Ці поля також можуть
-перезаписувати поля, створені автоматично драйвером, як описано в основній
-документації MongoDB для
-<link xlink:href="&url.mongodb.docs.gridfs;#the-files-collection"
-xmlns:xlink="http://www.w3.org/1999/xlink">колекцій файлів</link>. Практичним
-випадком використання такої поведінки є задати настроюваний
-<literal>chunkSize</literal> або <literal>_id</literal> для файлу.</para></note>'>
-
-<!ENTITY mongo.gridfs.store.return
-'<para xmlns="http://docbook.org/ns/docbook">Повертає <literal>_id</literal>
-збереженого файлу документу. Це згенерований <classname>MongoId</classname>, або
-явно вказаний <literal>_id</literal> в параметрі
-<parameter>metadata</parameter>.</para>'>
-
-<!ENTITY mongo.mongowritebatch.writeoptions.description
-'<listitem xmlns="http://docbook.org/ns/docbook"><para>Масив опцій запису.
-<informaltable><thead><row><entry>ключ</entry>
-<entry>значення</entry></row></thead><tbody><row><entry>w (int|string)</entry>
-<entry>значення <link linkend="mongo.writeconcerns">вимог щодо
-запису</link></entry></row><row><entry>wtimeout (int)</entry><entry><link
-linkend="mongo.writeconcerns">Допустимий час очікування
-реплікації</link></entry></row><row><entry>ordered</entry><entry>Вказує, чи
-потрібно MongoDB впорядковувати чергу. Впорядковані записи виконуються
-послідовно (тобто по одному) і виконання припиняється після першої помилки.
-Невпорядковані записи можуть виконуватися паралельно, а виконання не зупиниться
-після першої помилки. Початково: &true;</entry></row><row><entry>j
-(bool)</entry><entry>Очікувати на запис в жунал. Рекомендується використовувати
-WriteConcern натомість</entry></row><row><entry>fsync
-(bool)</entry><entry>Очікувати на fsync. Рекомендується використовувати
-WriteConcern натомість</entry></row></tbody></informaltable></para></listitem>'>
-
-<!ENTITY mongo.mongowritebatch.collection.description
-'<listitem xmlns="http://docbook.org/ns/docbook"><para>Черга
-<classname>MongoCollection</classname>. Її <link
-linkend="mongo.writeconcerns">вимоги щодо запису</link> будуть використані, якщо
-їх не надано через <parameter>$write_options</parameter> або
-<methodname>MongoWriteBatch::execute</methodname>.</para></listitem>'>
-
-<!ENTITY mongo.context.server
-'<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>server</parameter></term><listitem><para>Масив, що містить основну
-інформацію про обраний сервер.<informaltable><tgroup
-cols="2"><thead><row><entry>ключ</entry><entry>значення</entry></row></thead>
-<tbody><row><entry>hash</entry><entry>геш сервера, наприклад:
-<literal>localhost:27017;-;X;56052</literal></entry></row>
-<row><entry>type</entry><entry>Тип вузла (primary/secondary/mongos/arbiter):
-<literal>2</literal></entry></row><row><entry>max_bson_size</entry>
-<entry>Найбільший допустимий розмір BSON для передавання по вузлу:
-<literal>16777216</literal></entry></row><row><entry>max_message_size</entry>
-<entry>Найбільший допустимий розмір повідомлення для передавання по вузлу:
-<literal>48000000</literal></entry></row><row><entry>request_id</entry>
-<entry>Ідентифікатор запиту для цього повідомлення:
-<literal>42</literal></entry></row></tbody></tgroup></informaltable></para>
-</listitem></varlistentry>'>
-
-<!ENTITY mongo.context.writeoptions
-'<varlistentry xmlns="http://docbook.org/ns/docbook"><term>
-<parameter>writeOptions</parameter></term><listitem><para>
-<informaltable><tgroup cols="2"><thead><row><entry>ключ</entry>
-<entry>значення</entry></row></thead><tbody><row><entry>ordered (bool)</entry>
-<entry>Вказує, чи має операція (у випадку операції з чергою) виконуватися
-послідовно (ordered=true)</entry></row><row<entry>writeConcern</entry>
-<entry>Масив параметрів writeConcern (див.
-нижче)</entry></row></tbody></tgroup></informaltable><table<title>значення
-масиву writeConcern</title><tgroup cols="2><thead><row>
-<entry>ключ</entry><entry>значення</entry></row></thead>
-<tbody><row><entry>fsync (bool)</entry><entry>Чи записувати примусово на диск
-дані перед поверненням результату</entry></row><row><entry>j
-(bool)</entry><entry>Чи дописувати примусово в журнал перед поверненням
-результату</entry></row><row><entry>wtimeout (int)</entry><entry>Час очікування
-(в мілісекундах) основного процесу на перевірку
-реплікації</entry></row><row><entry>w (int|string)</entry><entry>Кількість
-серверів/тег реплікації</entry></row></tbody></tgroup></table></para></listitem>
-</varlistentry>'>
-
-<!ENTITY mongo.context.protocoloptions
-'<varlistentry xmlns="http://docbook.org/ns/docbook">
-<term><parameter>protocolOptions</parameter></term>
-<listitem><para><informaltable><tgroup cols="2"><thead><row<entry>ключ</entry>
-<entry>значення</entry></row></thead><tbody><row><entry>message_length</entry>
-<entry>Загальний розмір (в байтах) закодованого повідомлення, що
-надсилається</entry></row><row><entry>request_id</entry><entry>Ідентифікатор
-запиту для цього повідомлення: <literal>42</literal></entry></row>
-<row><entry>namespace</entry><entry>Простір імен MongoDB, що використовується
-для повідомлення протоколу
-<literal>dbname.collectionname</literal></entry></row></tbody></tgroup>
-</informaltable></para></listitem></varlistentry>'>
-
-<!ENTITY mongo.alternative.class.note
-'<para xmlns="http://docbook.org/ns/docbook">Розширення, яке визначає цей клас,
-застаріло. Натомість використовується розширення <link
-linkend="set.mongodb">MongoDB</link>. Цей клас можна замінити на:</para>'>
-
-<!ENTITY mongo.noalternative.class.note
-'<para xmlns="http://docbook.org/ns/docbook">Розширення, яке визначає цей клас,
-застаріло. Натомість використовується розширення <link
-linkend="set.mongodb">MongoDB</link>. Відповідників для цього класу
-немає.</para>'>
-
-<!ENTITY mongo.alternative.method.note
-'<para xmlns="http://docbook.org/ns/docbook">Розширення, яке визначає цей метод,
-застаріло. Натомість використовується розширення <link
-linkend="set.mongodb">MongoDB</link>. Цей метод можна замінити на:</para>'>
-
-<!ENTITY mongo.noalternative.method.note
-'<para xmlns="http://docbook.org/ns/docbook">Розширення, яке визначає цей метод,
-застаріло. Натомість використовується розширення <link
-linkend="set.mongodb">MongoDB</link>. Відповідників для цього методу
-немає.</para>'>
-
-<!ENTITY mongo.alternative.phplib.note
-'<para xmlns="http://docbook.org/ns/docbook">Розширення, яке визначає цей метод,
-застаріло. Натомість використовується розширення <link
-linkend="set.mongodb">MongoDB</link>. Відповідників для цього методу немає в
-новому роширенні, проте є в
-<link linkend="mongodb.overview">PHP-бібліотеці</link>:</para>'>
-
-<!ENTITY mongo.deprecated.note '<para
-xmlns="http://docbook.org/ns/docbook">Це розширення застаріло. Натомість
-використовується розширення <link linkend="set.mongodb">MongoDB</link>.</para>'>
 
 <!-- mongodb -->
 <!ENTITY mongodb.changelog.tentative-return-types '
@@ -4645,7 +4271,7 @@ local: {
                <row>
                 <entry>trimFactor</entry>
                 <entry><type>int</type></entry>
-                <entry>Обов&apos;язковий. Додатнє ціле 32-бітне число.</entry>
+                <entry>Необов&apos;язковий. Додатнє ціле 32-бітне число.</entry>
                </row>
               </tbody>
              </tgroup>
@@ -4906,6 +4532,56 @@ xmlns:xlink="http://www.w3.org/1999/xlink">libbson</link>.</member>'>
 '>
 
 <!-- strings snippets -->
+<!ENTITY strings.stripped.characters '
+ <itemizedlist xmlns="http://docbook.org/ns/docbook">
+    <listitem>
+     <simpara>
+      <literal>" "</literal>: символ <acronym>ASCII</acronym>
+      <acronym>SP</acronym> <literal>0x20</literal>, звичайний пропуск.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\t"</literal>: символ <acronym>ASCII</acronym>
+      <acronym>HT</acronym> <literal>0x09</literal>, табуляція.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\n"</literal>: символ <acronym>ASCII</acronym>
+      <acronym>LF</acronym> <literal>0x0A</literal>, новий рядок.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\r"</literal>: символ <acronym>ASCII</acronym>
+      <acronym>CR</acronym> <literal>0x0D</literal>, повернення каретки.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\0"</literal>: символ <acronym>ASCII</acronym>
+      <acronym>NUL</acronym> <literal>0x00</literal>, NUL-байт.
+     </simpara>
+    </listitem>
+    <listitem>
+     <simpara>
+      <literal>"\v"</literal>: символ <acronym>ASCII</acronym>
+      <acronym>VT</acronym> <literal>0x0B</literal>, вертикальна табуляція.
+     </simpara>
+    </listitem>
+   </itemizedlist>
+'>
+
+<!ENTITY strings.parameter.characters.optional '
+ <simpara xmlns="http://docbook.org/ns/docbook">
+  Символи, що треба вилучити, можна вказати за допомогою необов&apos;язкового
+  параметра <parameter>characters</parameter>. Необхідно просто записати туди
+  усі потрібні символи. За допомогою <literal>..</literal> можна задати діапазон
+  символів за зростанням.
+ </simpara>
+'>
+
 <!ENTITY strings.parameter.encoding '
  <para xmlns="http://docbook.org/ns/docbook">
   Необов&apos;язковий параметр. Ним вказується кодування, що застосовуватиметься

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: 17a5268812b06c23073609c4e8ab976ebfceb61b Maintainer: mproshchuk Status: ready -->
+<!-- EN-Revision: 5051184c4fb3fcfe5f3f01f4789d0149e3e1f945 Maintainer: mproshchuk Status: ready -->
 
 <!ENTITY installation.enabled.disable
 'Це розширення початково увімкнено. Для вимкнення застосовується наступна опція
@@ -422,6 +422,11 @@ linkend="userlandnaming" />.</simpara></tip>'>
 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Ця функція
 <emphasis>ЗАСТАРІЛА</emphasis>, починаючи з PHP 8.3.0. Вкрай не рекомендується
 на неї покладатися.</simpara></warning>'>
+
+<!ENTITY warn.deprecated.feature-8-4-0 '<warning
+xmlns="http://docbook.org/ns/docbook"><simpara>Цей функціонал
+<emphasis>ЗАСТАРІВ</emphasis>, починаючи з PHP 8.4.0. Вкрай не рекомендується на
+нього покладатися.</simpara></warning>'>
 
 <!ENTITY warn.deprecated.function-8-4-0
 '<warning xmlns="http://docbook.org/ns/docbook"><simpara>Ця функція

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -4703,7 +4703,7 @@ local: {
        <link linkend="types.comparisons">порівняння</link> і
        <link linkend="language.types.type-juggling">перетворення типів</link> в
        PHP. Для вибірки даних спеціальних BSON-типів, критерії запиту повинні
-       використовувати відповідний <link linkend="book.bson">клас BSON</link>
+       використовувати відповідний <link linkend="mongodb.bson">клас BSON</link>
        (напр. <classname>MongoDB\BSON\ObjectId</classname> для вибірки
        <link xlink:href="&url.mongodb.docs.objectid;"
        xmlns:xlink="http://www.w3.org/1999/xlink">ObjectId</link>).

--- a/language/oop5/visibility.xml
+++ b/language/oop5/visibility.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- EN-Revision: f5e5b54129045a7d02c5285a88cea0abff8ffb6f Maintainer: mproshchuk Status: ready -->
+<!-- EN-Revision: 7d7b378abd302430b8ce7cedb4b78c7033f5e88c Maintainer: mproshchuk Status: ready -->
  <sect1 xml:id="language.oop5.visibility" xmlns="http://docbook.org/ns/docbook">
   <title>Область видимості</title>
   <para>
    Області видимості властивостей, методів або (починаючи з PHP 7.1.0) констант
-   можуть визначатись через ключові слова <literal>public</literal>,
-   <literal>protected</literal> чи <literal>private</literal>. Доступ до членів
-   класу, оголошених як public (загальнодоступні), дозволено всюди. Члени класу,
-   оголошені як protected (захищені), доступні лише всередині самого класу, а
-   також через класи-нащадки та батьківські класи. Члени класу, оголошені як
-   private (закриті) можуть бути доступні лише через клас, де вони визначені.
+   можуть визначатись через ключові слова <literal>public</literal>
+   (загальнодоступно), <literal>protected</literal> (захищено) чи
+   <literal>private</literal> (закрито). Доступ до членів класу, оголошених як
+   загальнодоступні, дозволено всюди. Члени класу, оголошені як захищені,
+   доступні лише всередині самого класу, а також через класи-нащадки та
+   батьківські класи. Члени класу, оголошені як закриті можуть бути доступні
+   лише в класі, де вони визначені.
   </para>
 
   <sect2 xml:id="language.oop5.visibility-members">
    <title>Видимість властивості</title>
    <para>
-    Властивості класу можуть оголошуватись як public, private чи protected.
-    Властивість, оголошена без ключового слова видимості, вважається
+    Властивості класу можуть оголошуватись як загальнодоступні, захищені чи
+    закриті. Властивість, оголошена без ключового слова видимості, вважається
     загальнодоступною.
    </para>
-   <para>
-    <example>
-     <title>Оголошення властивості</title>
-     <programlisting role="php">
+   <example>
+    <title>Оголошення властивості</title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 /**
@@ -74,9 +74,131 @@ $obj2->printHello(); // Виводить Загальнодоступна2, За
 
 ?> 
 ]]>
+    </programlisting>
+   </example>
+   <sect3 xml:id="language.oop5.visibility-members-aviz">
+    <title>Асиметрична видимість властивості</title>
+    <simpara>
+     Починаючи з PHP 8.4, властивості можуть мати асиметричну видимість, з
+     різними областями видимості для читання (<literal>get</literal>) та запису
+     (<literal>set</literal>). Зокрема видимість <literal>set</literal> можна
+     вказати окремо, якщо та не є ширшою за типову.
+    </simpara>
+    <example>
+     <title>Асиметрична видимість властивості</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+class Book
+{
+    public function __construct(
+        public private(set) string $title,
+        public protected(set) string $author,
+        protected private(set) int $pubYear,
+    ) {}
+}
+
+class SpecialBook extends Book
+{
+    public function update(string $author, int $year): void
+    {
+        $this->author = $author; // Працює
+        $this->pubYear = $year; // Fatal Error
+    }
+}
+
+$b = new Book('Програмування на PHP', 'Петро Петрук', 2024);
+
+echo $b->title; // Працює
+echo $b->author; // Працює
+echo $b->pubYear; // Fatal Error
+
+$b->title = 'Як не програмувати на PHP'; // Fatal Error
+$b->author = 'Павло Петрук'; // Fatal Error
+$b->pubYear = 2023; // Fatal Error
+?>
+]]>
      </programlisting>
     </example>
-   </para>
+    <para>Є кілька застережень щодо асиметричної видимості:</para>
+    <itemizedlist>
+     <listitem>
+      <simpara>
+       Тільки властивості з вказаним типом можуть мати окрему видимість
+       <literal>set</literal>.
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       Видимість <literal>set</literal> має бути однаковою з
+       <literal>get</literal> або вужчою. Тобто код <code>public
+       protected(set)</code> та <code>protected protected(set)</code>
+       працюватиме, але <code>protected public(set)</code> викличе помилку
+       синтаксису.
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       Якщо властивість є загальнодоступною (<literal>public</literal>), то
+       основну видимість можна не оголошувати. Тобто, код <code>public
+       private(set)</code> і <code>private(set)</code> працюватиме однаково.
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       Властивість з видимістю <literal>private(set)</literal> автоматично є
+       фінальною (<literal>final</literal>), та не може бути змінена в
+       класі-нащадку.
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       На отримання посилання впливає видимість <literal>set</literal>, а не
+       <literal>get</literal>. Це тому, що посилання може бути використано, щоб
+       змінити значення властивості.
+      </simpara>
+     </listitem>
+     <listitem>
+      <simpara>
+       Відповідно, запис до властивості-масиву включає в себе як
+       <literal>get</literal>-, так і <literal>set</literal>-операції, а отже до
+       уваги братиметься видимість <literal>set</literal>, як більш
+       обмежувальна.
+      </simpara>
+     </listitem>
+    </itemizedlist>
+    <simpara>
+     Клас-нащадок може перевизначати властивість батьківського класу, якщо та не
+     фінальна (<literal>final</literal>). Таким чином він може розширити основну
+     видимість, або видимість <literal>set</literal>, за умови, що нова
+     видимість є такою самою або ширшою, ніж в батьківського класу. Слід зважати
+     на те, що якщо закрита (<literal>private</literal>) властивість
+     перезаписується, то це не впливає на батьківську властивість, а створює
+     нову властивість з іншою внутрішньою назвою.
+    </simpara>
+    <example>
+     <title>Асиметричне наслідування властивості</title>
+     <programlisting role="php">
+<![CDATA[
+<?php
+class Book
+{
+    protected string $title;
+    public protected(set) string $author;
+    protected private(set) int $pubYear;
+}
+
+class SpecialBook extends Book
+{
+    public protected(set) $title; // Все гаразд. Видимість читання ширша, а запису така сама.
+    public string $author; // Все гаразд. Видимість така сама, а читання ширша.
+    public protected(set) int $pubYear; // Фатальна помилка. властивість з видимістю private(set) є фінальною.
+}
+?>
+]]>
+     </programlisting>
+    </example>
+   </sect3>
   </sect2>
 
   <sect2 xml:id="language.oop5.visiblity-methods">
@@ -85,10 +207,9 @@ $obj2->printHello(); // Виводить Загальнодоступна2, За
     Методи класу можуть бути визначені як public, private чи protected. Метод,
     оголошений без ключового слова видимості, вважається загальнодоступним.
    </para>
-   <para>
-    <example>
-     <title>Оголошення метода</title>
-     <programlisting role="php">
+   <example>
+    <title>Оголошення метода</title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 /**
@@ -96,16 +217,16 @@ $obj2->printHello(); // Виводить Загальнодоступна2, За
  */
 class MyClass
 {
-    // Оголошення загальнодоступного (публічного) конструктора
+    // Оголошення загальнодоступного конструктора
     public function __construct() { }
 
-    // Оголошення публічного метода
+    // Оголошення загальнодоступного методу
     public function MyPublic() { }
 
-    // Оголошення захищеного метода
+    // Оголошення захищеного методу
     protected function MyProtected() { }
 
-    // Оголошення закритого метода
+    // Оголошення закритого методу
     private function MyPrivate() { }
 
     // Таке оголошення метода буде оброблятись як public метод
@@ -129,7 +250,7 @@ $myclass->Foo(); // Працюють Public, Protected та Private методи
  */
 class MyClass2 extends MyClass
 {
-    // Таке оголошення метода буде оброблятись як public метод
+    // Таке оголошення методу буде оброблятись як public
     function Foo2()
     {
         $this->MyPublic();
@@ -174,9 +295,8 @@ $myFoo->test(); // Bar::testPrivate
                 // Foo::testPublic
 ?>
 ]]>
-     </programlisting>
-    </example>
-   </para>
+    </programlisting>
+   </example>
   </sect2>
 
   <sect2 xml:id="language.oop5.visiblity-constants">
@@ -186,10 +306,9 @@ $myFoo->test(); // Bar::testPrivate
     private чи protected. Константа, оголошена без ключового слова видимості,
     вважається загальнодоступною.
    </para>
-   <para>
-    <example>
-     <title>Оголошення констант, починаючи з PHP 7.1.0</title>
-     <programlisting role="php">
+   <example>
+    <title>Оголошення констант, починаючи з PHP 7.1.0</title>
+    <programlisting role="php">
 <![CDATA[
 <?php
 /**
@@ -240,9 +359,8 @@ echo MyClass2::MY_PUBLIC; // Працює
 $myclass2->foo2(); // Працюють константи Public та Protected, але не Private
 ?>
 ]]>
-     </programlisting>
-    </example>
-   </para>
+    </programlisting>
+   </example>
   </sect2>
 
   <sect2 xml:id="language.oop5.visibility-other-objects">
@@ -269,13 +387,13 @@ class Test
 
     private function bar()
     {
-        echo 'Доступ до закритого метода.';
+        echo 'Доступ до закритого методу.';
     }
 
     public function baz(Test $other)
     {
         // Ми можемо змінити закриту властивість:
-        $other->foo = 'hello';
+        $other->foo = 'привіт';
         var_dump($other->foo);
 
         // Ми також можемо викликати закритий метод:
@@ -292,8 +410,8 @@ $test->baz(new Test('other'));
     &example.outputs;
     <screen>
 <![CDATA[
-string(5) "hello"
-Доступ до закритого метода.
+string(12) "привіт"
+Доступ до закритого методу.
 ]]>
     </screen>
    </example>


### PR DESCRIPTION
The [`language/oop5/visibility.xml`](https://doc.php.net/revcheck.php?p=plain&lang=uk&hbp=f5e5b54129045a7d02c5285a88cea0abff8ffb6f&f=language/oop5/visibility.xml&c=on) file needs to be synced to fix the build due to the new Aziv IDs.

Ideally, to fix the soon-to-be RelaxNG validated builds the [`install/unix/nginx.xml`](https://doc.php.net/revcheck.php?p=plain&lang=uk&hbp=e2788930738ece61eb73efa693bf783b68fc56fa&f=install/unix/nginx.xml&c=on) file should also be prioritized for syncing