### PR TITLE
Add translation for fdatasync() and fsync()

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -45,6 +45,33 @@
        </para> 
       </listitem>
      </varlistentry>
+     <varlistentry xml:id="log-limit">
+      <term>
+       <parameter>log_limit</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <para>
+        Обмеження журналу для рядків, що записуються до журналу, яке дозволяє
+        записувати повідомлення довші за 1024 символи без обрізання.
+        Початкове значення: 1024.
+        Доступно з PHP 7.3.0.
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="log-buffering">
+      <term>
+       <parameter>log_buffering</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Експериментальне буферизоване журналювання без додаткового виділення пам'яті.
+        Початкове значення: yes.
+        Доступно з PHP 7.3.0.
+       </para>
+      </listitem>
+     </varlistentry>
      <varlistentry xml:id="emergency-restart-threshold">
       <term>
        <parameter>emergency_restart_threshold</parameter>

--- a/reference/filesystem/functions/fdatasync.xml
+++ b/reference/filesystem/functions/fdatasync.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 21129de1745eb016452f0ce8a2c3e47fbb8484de Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.fdatasync" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>fdatasync</refname>
+  <refpurpose>Синхронізує дані (але не метадані) у файл</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>fdatasync</methodname>
+   <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ця функція синхронізує вміст <parameter>stream</parameter> на носій
+   даних, так само як <function>fsync</function>, але не синхронізує
+   метадані файлу. Зверніть увагу, що ця функція фактично відрізняється
+   лише в системах POSIX. У Windows ця функція є псевдонімом
+   <function>fsync</function>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>stream</parameter></term>
+     <listitem>
+      &fs.validfp.all;
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Приклад використання <function>fdatasync</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$file = 'test.txt';
+
+$stream = fopen($file, 'w');
+fwrite($stream, 'test data');
+fwrite($stream, "\r\n");
+fwrite($stream, 'additional data');
+
+fdatasync($stream);
+fclose($stream);
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>fflush</function></member>
+    <member><function>fsync</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/filesystem/functions/fsync.xml
+++ b/reference/filesystem/functions/fsync.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 21129de1745eb016452f0ce8a2c3e47fbb8484de Maintainer: lacatoire Status: ready -->
+<refentry xml:id="function.fsync" xmlns="http://docbook.org/ns/docbook">
+ <refnamediv>
+  <refname>fsync</refname>
+  <refpurpose>Синхронізує зміни у файлі (включно з метаданими)</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>bool</type><methodname>fsync</methodname>
+   <methodparam><type>resource</type><parameter>stream</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Ця функція синхронізує зміни у файлі, включно з його метаданими. Це
+   подібно до <function>fflush</function>, але додатково дає вказівку
+   операційній системі записати дані на носій.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>stream</parameter></term>
+     <listitem>
+      &fs.validfp.all;
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   &return.success;
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Приклад використання <function>fsync</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+
+$file = 'test.txt';
+
+$stream = fopen($file, 'w');
+fwrite($stream, 'test data');
+fwrite($stream, "\r\n");
+fwrite($stream, 'additional data');
+
+fsync($stream);
+fclose($stream);
+?>
+]]>
+    </programlisting>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>fdatasync</function></member>
+    <member><function>fflush</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Add missing Ukrainian translations for `fdatasync()` and `fsync()` filesystem functions.