### PR TITLE
Add translation for str_increment() and str_decrement()

### DIFF
--- a/install/fpm/configuration.xml
+++ b/install/fpm/configuration.xml
@@ -45,6 +45,33 @@
        </para> 
       </listitem>
      </varlistentry>
+     <varlistentry xml:id="log-limit">
+      <term>
+       <parameter>log_limit</parameter>
+       <type>int</type>
+      </term>
+      <listitem>
+       <para>
+        Обмеження журналу для рядків, що записуються до журналу, яке дозволяє
+        записувати повідомлення довші за 1024 символи без обрізання.
+        Початкове значення: 1024.
+        Доступно з PHP 7.3.0.
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry xml:id="log-buffering">
+      <term>
+       <parameter>log_buffering</parameter>
+       <type>bool</type>
+      </term>
+      <listitem>
+       <para>
+        Експериментальне буферизоване журналювання без додаткового виділення пам'яті.
+        Початкове значення: yes.
+        Доступно з PHP 7.3.0.
+       </para>
+      </listitem>
+     </varlistentry>
      <varlistentry xml:id="emergency-restart-threshold">
       <term>
        <parameter>emergency_restart_threshold</parameter>

--- a/reference/strings/functions/str-decrement.xml
+++ b/reference/strings/functions/str-decrement.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 57c83578be2f0ebf3528f1296040fe738dac37de Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.str-decrement">
+ <refnamediv>
+  <refname>str_decrement</refname>
+  <refpurpose>Декрементує алфавітно-цифровий рядок</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>str_decrement</methodname>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Повертає декрементований алфавітно-цифровий рядок
+   <acronym>ASCII</acronym> <parameter>string</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>string</parameter></term>
+     <listitem>
+      <para>
+       Вхідний рядок.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Повертає декрементований алфавітно-цифровий рядок
+   <acronym>ASCII</acronym>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Якщо <parameter>string</parameter> порожній, буде викинуто
+   <classname>ValueError</classname>.
+  </para>
+  <para>
+   Якщо <parameter>string</parameter> не є алфавітно-цифровим рядком
+   <acronym>ASCII</acronym>, буде викинуто
+   <classname>ValueError</classname>.
+  </para>
+  <para>
+   Якщо <parameter>string</parameter> не може бути декрементований,
+   буде викинуто <classname>ValueError</classname>.
+   Наприклад, <literal>"A"</literal> або <literal>"0"</literal>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Базовий приклад <function>str_decrement</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$str = 'ABC';
+var_dump(str_decrement($str));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(3) "ABB"
+]]>
+    </screen>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Приклад <function>str_decrement</function> з перенесенням</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$str = 'ZA';
+var_dump(str_decrement($str));
+
+$str = 'AA';
+var_dump(str_decrement($str));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(2) "YZ"
+string(1) "Z"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>str_increment</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/strings/functions/str-increment.xml
+++ b/reference/strings/functions/str-increment.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- EN-Revision: 57c83578be2f0ebf3528f1296040fe738dac37de Maintainer: lacatoire Status: ready -->
+<refentry xmlns="http://docbook.org/ns/docbook" xml:id="function.str-increment">
+ <refnamediv>
+  <refname>str_increment</refname>
+  <refpurpose>Інкрементує алфавітно-цифровий рядок</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <type>string</type><methodname>str_increment</methodname>
+   <methodparam><type>string</type><parameter>string</parameter></methodparam>
+  </methodsynopsis>
+  <para>
+   Повертає інкрементований алфавітно-цифровий рядок
+   <acronym>ASCII</acronym> <parameter>string</parameter>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>string</parameter></term>
+     <listitem>
+      <para>
+       Вхідний рядок.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Повертає інкрементований алфавітно-цифровий рядок
+   <acronym>ASCII</acronym>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <para>
+   Якщо <parameter>string</parameter> порожній, буде викинуто
+   <classname>ValueError</classname>.
+  </para>
+  <para>
+   Якщо <parameter>string</parameter> не є алфавітно-цифровим рядком
+   <acronym>ASCII</acronym>, буде викинуто
+   <classname>ValueError</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="examples">
+  &reftitle.examples;
+  <para>
+   <example>
+    <title>Базовий приклад <function>str_increment</function></title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$str = 'ABC';
+var_dump(str_increment($str));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(3) "ABD"
+]]>
+    </screen>
+   </example>
+  </para>
+  <para>
+   <example>
+    <title>Приклад <function>str_increment</function> з перенесенням</title>
+    <programlisting role="php">
+<![CDATA[
+<?php
+$str = 'DZ';
+var_dump(str_increment($str));
+
+$str = 'ZZ';
+var_dump(str_increment($str));
+?>
+]]>
+    </programlisting>
+    &example.outputs;
+    <screen>
+<![CDATA[
+string(2) "EA"
+string(3) "AAA"
+]]>
+    </screen>
+   </example>
+  </para>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <para>
+   <simplelist>
+    <member><function>str_decrement</function></member>
+   </simplelist>
+  </para>
+ </refsect1>
+
+</refentry>
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->


### PR DESCRIPTION
Add missing Ukrainian translations for the PHP 8.3 `str_increment()` and `str_decrement()` string functions.